### PR TITLE
Ignore contribution section in toc

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,8 @@
     "markdown.extension.toc.levels": "2..6",
     "markdown.extension.toc.omittedFromToc": {
         "readme.md": [
-            "## Contents"
+            "## Contents",
+            "## Contributing"
         ]
     },
 }

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,6 @@ Improving the quality, accuracy, and reproducibility of clinical study reporting
 - [Community](#community)
 - [Follow](#follow)
 
-
 <!-- CONTENT -->
 
 **Legend**: 📝 PharmaSUG Reports · 💡 examples · 📖 docs · 🔌 libraries · 📦 packages · 📹 talks/video


### PR DESCRIPTION
This PR skips adding the "contributing" section to the auto-generated TOC from Markdown All in One by specifying it in `settings.json`. This helps avoid the linting error consistently.